### PR TITLE
Update README documentation file

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,10 @@
+image:https://godoc.org/gitlab.com/jhinrichsen/adventofcode2018?status.svg["godoc", link="https://godoc.org/gitlab.com/jhinrichsen/adventofcode2018"]
+image:https://goreportcard.com/badge/gitlab.com/jhinrichsen/adventofcode2018["Go report card", link="https://goreportcard.com/report/gitlab.com/jhinrichsen/adventofcode2018"]
 image:https://gitlab.com/jhinrichsen/adventofcode2018/badges/master/pipeline.svg[link="https://gitlab.com/jhinrichsen/adventofcode2018/-/commits/master",title="pipeline status"]
 image:https://gitlab.com/jhinrichsen/adventofcode2018/badges/master/coverage.svg[link="https://gitlab.com/jhinrichsen/adventofcode2018/-/commits/master",title="coverage report"]
 
 = Advent Of Code (AOC) 2018
+:toc:
 
 My take on the AOC, documenting my errors.
 
@@ -19,7 +22,7 @@ Solutions are hardcoded into unit tests, so you won't see any solutions as
 long as you avoid looking at `*_test.go` files.
 
 == Environment
-- Go 1.25
+- Go 1.17
 - vim, vim-go, gopls, fed by an HHKB
 - VisualStudio Code for complex debugging scenarios
 - Fedora 34
@@ -34,18 +37,14 @@ long as you avoid looking at `*_test.go` files.
 - Fedora 42
 - Framework Laptop 16"
 
-=== Update 2
+=== Update 2 (Nov 2025)
 - Go 1.25
 - Claude Code
 - Claude Code Web (Research preview)
+- Fedora 43
 - Intel i7 14700
 
 The package name is `adventofcode2018`.
-
-Each day lives separately in a `day{{.02n}}.go` and `day{{.02n}}_test.go` file.
-Unit test data, both examples and puzzle input, is in
-`testdata/day{{.02n}}.txt`, and `testdata/day{{.02n}}_example.txt`.
-
 
 |===
 | Day | Tries
@@ -59,10 +58,10 @@ Unit test data, both examples and puzzle input, is in
 |  5  |
 |  6  |
 |  7  |
-|  8  | 1 |
+|  8  | 1
 |  9  |
 | 10  |
-| 11  | 2 |
+| 11  | 2
 | 12  |
 | 13  |
 | 14  |
@@ -93,14 +92,11 @@ Numbers in (brackets) indicate tries so far (part #2 not solved yet).
 == Day 10: The Stars Align
 == Day 11: Chronal Charge
 
-[WARNING]
-====
 Part 2 required 2 tries. Initial submission was `231,107,14` but the correct answer was `229,192,11`.
 
 The implementation using summed-area table was correct. The issue was a test failure due to an incorrect expected value - I had guessed the wrong answer when writing the test before running the actual computation.
 
 After debugging with a standalone program, verified the algorithm produces correct results for both examples (serial 18 → 90,269,16 and serial 42 → 232,251,12) and the puzzle input (serial 9424 → 229,192,11, an 11×11 square at position 229,192 with total power 74).
-====
 
 == Day 12: Subterranean Sustainability
 == Day 13: Mine Cart Madness
@@ -116,6 +112,16 @@ After debugging with a standalone program, verified the algorithm produces corre
 == Day 23: Experimental Emergency Teleportation
 == Day 24: Immune System Simulator 20XX
 == Day 25: Four-Dimensional Adventure
+
+== Benchmarks
+
+Run with `go test -run=^$ -bench=Day..Part.$`
+
+----
+goos: linux
+goarch: amd64
+pkg: gitlab.com/jhinrichsen/adventofcode2018
+----
 
 == References
 


### PR DESCRIPTION
- Add TOC for better navigation
- Add godoc and goreportcard badges
- Update environment: Go 1.17 for original setup
- Add Nov 2025 to Update 2 with Fedora 43
- Remove day structure documentation (now in CONTRIBUTING.adoc)
- Fix tries table formatting for days 8-11
- Convert Day 11 warning to regular paragraphs
- Add Benchmarks section with command reference